### PR TITLE
Prevent snapshots from erring when node is null

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { ASTNode } from 'graphql';
 
 export const isGraphqlSchema = (node: ASTNode): boolean => {
-  if (typeof node === 'object' && node.kind && node.loc) {
+  if (node && typeof node === 'object' && node.kind && node.loc) {
     return true;
   }
   return false;

--- a/tests/__snapshots__/index.spec.ts.snap
+++ b/tests/__snapshots__/index.spec.ts.snap
@@ -22,3 +22,5 @@ type Mutation {
   login(emailAddress: String!, password: String!): User
 }
 `;
+
+exports[`graphql schema should not fail if the provided node is null 1`] = `null`;

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -36,4 +36,10 @@ describe('graphql schema', (): void => {
     const ast = gql(query);
     expect(ast).toMatchSnapshot();
   });
+
+  it('should not fail if the provided node is null', () => {
+    expect.addSnapshotSerializer(createSerializer());
+
+    expect(null).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
If a snapshot of something returning `null` is requested and this package is in use, we see the following error:

```
PrettyFormatPluginError: Cannot read property 'kind' of nullTypeError: Cannot read property 'kind' of null
```

By checking that the `node` is truthy, we can avoid this.